### PR TITLE
feat: add LoadingStrategy with simplified two-variant design

### DIFF
--- a/src/mutation.rs
+++ b/src/mutation.rs
@@ -284,7 +284,7 @@ impl<Q: MutationCapability> Mutation<Q> {
     /// Set the loading strategy for this mutation.
     ///
     /// Controls whether the mutation transitions to Loading state during execution.
-    /// Defaults to [LoadingStrategy::AlwaysShow].
+    /// Defaults to [LoadingStrategy::Skip].
     pub fn loading_strategy(self, loading_strategy: LoadingStrategy) -> Self {
         Self {
             loading_strategy,

--- a/src/mutation.rs
+++ b/src/mutation.rs
@@ -200,14 +200,8 @@ impl<Q: MutationCapability> MutationsStorage<Q> {
     }
 
     async fn run(mutation: &Mutation<Q>, data: &MutationData<Q>, keys: Q::Keys) {
-        // Determine if we should transition to Loading state based on strategy
-        let should_show_loading = match mutation.loading_strategy {
-            LoadingStrategy::Full => true,
-            LoadingStrategy::Memoized => false,
-        };
-
-        if should_show_loading {
-            // Set to Loading
+        // Transition to Loading state if using Full strategy
+        if let LoadingStrategy::Full = mutation.loading_strategy {
             let res = mem::replace(&mut *data.state.borrow_mut(), MutationStateData::Pending)
                 .into_loading();
             *data.state.borrow_mut() = res;
@@ -262,7 +256,6 @@ impl<Q: MutationCapability> Eq for Mutation<Q> {}
 impl<Q: MutationCapability> Hash for Mutation<Q> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.mutation.hash(state);
-        self.loading_strategy.hash(state);
     }
 }
 

--- a/src/mutation.rs
+++ b/src/mutation.rs
@@ -279,6 +279,79 @@ impl<Q: MutationCapability> Mutation<Q> {
     ///
     /// Controls whether the mutation transitions to Loading state during execution.
     /// Defaults to [LoadingStrategy::Memoized].
+    ///
+    /// # Examples
+    ///
+    /// ## Memoized strategy for idempotent mutations
+    ///
+    /// ```rust
+    /// use dioxus_query::*;
+    /// # use dioxus::prelude::*;
+    /// # #[derive(Clone, PartialEq, Hash)]
+    /// # struct UpdatePreferencesMutation;
+    /// # impl MutationCapability for UpdatePreferencesMutation {
+    /// #     type Ok = ();
+    /// #     type Err = String;
+    /// #     type Keys = bool;
+    /// #     async fn run(&self, dark_mode: &bool) -> Result<(), String> { Ok(()) }
+    /// # }
+    ///
+    /// fn Settings() -> Element {
+    ///     // For toggles/preferences, avoid showing loading on every click
+    ///     let update_prefs = use_mutation(
+    ///         Mutation::new(UpdatePreferencesMutation)
+    ///             .loading_strategy(LoadingStrategy::Memoized) // default
+    ///     );
+    ///
+    ///     rsx! {
+    ///         button {
+    ///             onclick: move |_| {
+    ///                 // No loading state shown for quick operations
+    ///                 update_prefs.mutate(true);
+    ///             },
+    ///             "Enable Dark Mode"
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ## Full strategy for important operations
+    ///
+    /// ```rust
+    /// use dioxus_query::*;
+    /// # use dioxus::prelude::*;
+    /// # #[derive(Clone, PartialEq, Hash)]
+    /// # struct DeleteAccountMutation;
+    /// # impl MutationCapability for DeleteAccountMutation {
+    /// #     type Ok = ();
+    /// #     type Err = String;
+    /// #     type Keys = u32;
+    /// #     async fn run(&self, user_id: &u32) -> Result<(), String> { Ok(()) }
+    /// # }
+    ///
+    /// fn DeleteAccount() -> Element {
+    ///     // Show loading indicator for critical operations
+    ///     let delete_account = use_mutation(
+    ///         Mutation::new(DeleteAccountMutation)
+    ///             .loading_strategy(LoadingStrategy::Full)
+    ///     );
+    ///
+    ///     rsx! {
+    ///         button {
+    ///             onclick: move |_| {
+    ///                 // User sees clear feedback during deletion
+    ///                 delete_account.mutate(123);
+    ///             },
+    ///             disabled: delete_account.read().state().is_loading(),
+    ///             if delete_account.read().state().is_loading() {
+    ///                 "Deleting..."
+    ///             } else {
+    ///                 "Delete Account"
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    /// ```
     pub fn loading_strategy(self, loading_strategy: LoadingStrategy) -> Self {
         Self {
             loading_strategy,

--- a/src/query.rs
+++ b/src/query.rs
@@ -242,13 +242,12 @@ impl<Q: QueryCapability> Clone for QueryData<Q> {
 
 /// Builder for invalidating all queries with configurable loading strategy.
 /// Implements IntoFuture so it can be used with `.await`.
-pub struct InvalidateAll<'a, Q: QueryCapability> {
+pub struct InvalidateAll<Q: QueryCapability> {
     storage: QueriesStorage<Q>,
     loading_strategy_override: Option<LoadingStrategy>,
-    _phantom: std::marker::PhantomData<&'a ()>,
 }
 
-impl<'a, Q: QueryCapability> InvalidateAll<'a, Q> {
+impl<Q: QueryCapability> InvalidateAll<Q> {
     /// Override the loading strategy for all invalidated queries.
     /// By default, each query uses its own configured loading_strategy.
     pub fn loading_strategy(mut self, strategy: LoadingStrategy) -> Self {
@@ -257,9 +256,9 @@ impl<'a, Q: QueryCapability> InvalidateAll<'a, Q> {
     }
 }
 
-impl<'a, Q: QueryCapability> IntoFuture for InvalidateAll<'a, Q> {
+impl<Q: QueryCapability> IntoFuture for InvalidateAll<Q> {
     type Output = ();
-    type IntoFuture = Pin<Box<dyn Future<Output = ()> + 'a>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = ()>>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
@@ -290,14 +289,13 @@ impl<'a, Q: QueryCapability> IntoFuture for InvalidateAll<'a, Q> {
 
 /// Builder for invalidating matching queries with configurable loading strategy.
 /// Implements IntoFuture so it can be used with `.await`.
-pub struct InvalidateMatching<'a, Q: QueryCapability> {
+pub struct InvalidateMatching<Q: QueryCapability> {
     storage: QueriesStorage<Q>,
     matching_keys: Q::Keys,
     loading_strategy_override: Option<LoadingStrategy>,
-    _phantom: std::marker::PhantomData<&'a ()>,
 }
 
-impl<'a, Q: QueryCapability> InvalidateMatching<'a, Q> {
+impl<Q: QueryCapability> InvalidateMatching<Q> {
     /// Override the loading strategy for all invalidated queries.
     /// By default, each query uses its own configured loading_strategy.
     pub fn loading_strategy(mut self, strategy: LoadingStrategy) -> Self {
@@ -306,9 +304,9 @@ impl<'a, Q: QueryCapability> InvalidateMatching<'a, Q> {
     }
 }
 
-impl<'a, Q: QueryCapability> IntoFuture for InvalidateMatching<'a, Q> {
+impl<Q: QueryCapability> IntoFuture for InvalidateMatching<Q> {
     type Output = ();
-    type IntoFuture = Pin<Box<dyn Future<Output = ()> + 'a>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = ()>>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
@@ -341,13 +339,12 @@ impl<'a, Q: QueryCapability> IntoFuture for InvalidateMatching<'a, Q> {
 
 /// Builder for trying to invalidate all queries without panicking if context doesn't exist.
 /// Implements IntoFuture so it can be used with `.await`.
-pub struct TryInvalidateAll<'a, Q: QueryCapability> {
+pub struct TryInvalidateAll<Q: QueryCapability> {
     storage: Option<QueriesStorage<Q>>,
     loading_strategy_override: Option<LoadingStrategy>,
-    _phantom: std::marker::PhantomData<&'a ()>,
 }
 
-impl<'a, Q: QueryCapability> TryInvalidateAll<'a, Q> {
+impl<Q: QueryCapability> TryInvalidateAll<Q> {
     /// Override the loading strategy for all invalidated queries.
     /// By default, each query uses its own configured loading_strategy.
     pub fn loading_strategy(mut self, strategy: LoadingStrategy) -> Self {
@@ -356,9 +353,9 @@ impl<'a, Q: QueryCapability> TryInvalidateAll<'a, Q> {
     }
 }
 
-impl<'a, Q: QueryCapability> IntoFuture for TryInvalidateAll<'a, Q> {
+impl<Q: QueryCapability> IntoFuture for TryInvalidateAll<Q> {
     type Output = bool;
-    type IntoFuture = Pin<Box<dyn Future<Output = bool> + 'a>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = bool>>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
@@ -392,14 +389,13 @@ impl<'a, Q: QueryCapability> IntoFuture for TryInvalidateAll<'a, Q> {
 
 /// Builder for trying to invalidate matching queries without panicking if context doesn't exist.
 /// Implements IntoFuture so it can be used with `.await`.
-pub struct TryInvalidateMatching<'a, Q: QueryCapability> {
+pub struct TryInvalidateMatching<Q: QueryCapability> {
     storage: Option<QueriesStorage<Q>>,
     matching_keys: Q::Keys,
     loading_strategy_override: Option<LoadingStrategy>,
-    _phantom: std::marker::PhantomData<&'a ()>,
 }
 
-impl<'a, Q: QueryCapability> TryInvalidateMatching<'a, Q> {
+impl<Q: QueryCapability> TryInvalidateMatching<Q> {
     /// Override the loading strategy for all invalidated queries.
     /// By default, each query uses its own configured loading_strategy.
     pub fn loading_strategy(mut self, strategy: LoadingStrategy) -> Self {
@@ -408,9 +404,9 @@ impl<'a, Q: QueryCapability> TryInvalidateMatching<'a, Q> {
     }
 }
 
-impl<'a, Q: QueryCapability> IntoFuture for TryInvalidateMatching<'a, Q> {
+impl<Q: QueryCapability> IntoFuture for TryInvalidateMatching<Q> {
     type Output = bool;
-    type IntoFuture = Pin<Box<dyn Future<Output = bool> + 'a>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = bool>>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
@@ -602,12 +598,11 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     ///     .loading_strategy(LoadingStrategy::Full)
     ///     .await;
     /// ```
-    pub fn invalidate_all() -> InvalidateAll<'static, Q> {
+    pub fn invalidate_all() -> InvalidateAll<Q> {
         let storage = consume_context::<QueriesStorage<Q>>();
         InvalidateAll {
             storage,
             loading_strategy_override: None,
-            _phantom: std::marker::PhantomData,
         }
     }
 
@@ -626,13 +621,12 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     ///     .loading_strategy(LoadingStrategy::Memoized)
     ///     .await;
     /// ```
-    pub fn invalidate_matching(matching_keys: Q::Keys) -> InvalidateMatching<'static, Q> {
+    pub fn invalidate_matching(matching_keys: Q::Keys) -> InvalidateMatching<Q> {
         let storage = consume_context::<QueriesStorage<Q>>();
         InvalidateMatching {
             storage,
             matching_keys,
             loading_strategy_override: None,
-            _phantom: std::marker::PhantomData,
         }
     }
 
@@ -652,12 +646,11 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     ///     .loading_strategy(LoadingStrategy::Full)
     ///     .await;
     /// ```
-    pub fn try_invalidate_all() -> TryInvalidateAll<'static, Q> {
+    pub fn try_invalidate_all() -> TryInvalidateAll<Q> {
         let storage = try_consume_context::<QueriesStorage<Q>>();
         TryInvalidateAll {
             storage,
             loading_strategy_override: None,
-            _phantom: std::marker::PhantomData,
         }
     }
 
@@ -677,13 +670,12 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     ///     .loading_strategy(LoadingStrategy::Memoized)
     ///     .await;
     /// ```
-    pub fn try_invalidate_matching(matching_keys: Q::Keys) -> TryInvalidateMatching<'static, Q> {
+    pub fn try_invalidate_matching(matching_keys: Q::Keys) -> TryInvalidateMatching<Q> {
         let storage = try_consume_context::<QueriesStorage<Q>>();
         TryInvalidateMatching {
             storage,
             matching_keys,
             loading_strategy_override: None,
-            _phantom: std::marker::PhantomData,
         }
     }
 
@@ -814,14 +806,8 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
         for (query, query_data) in queries {
             let loading_strategy = query.loading_strategy;
 
-            // Determine if we should transition to Loading state based on strategy
-            let should_show_loading = match loading_strategy {
-                LoadingStrategy::Full => true,
-                LoadingStrategy::Memoized => false,
-            };
-
-            if should_show_loading {
-                // Set to Loading
+            // Transition to Loading state if using Full strategy
+            if let LoadingStrategy::Full = loading_strategy {
                 let res =
                     mem::replace(&mut *query_data.state.borrow_mut(), QueryStateData::Pending)
                         .into_loading();
@@ -880,14 +866,8 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
         let tasks = FuturesUnordered::new();
 
         for (query, query_data) in queries {
-            // Determine if we should transition to Loading state based on strategy
-            let should_show_loading = match loading_strategy {
-                LoadingStrategy::Full => true,
-                LoadingStrategy::Memoized => false,
-            };
-
-            if should_show_loading {
-                // Set to Loading
+            // Transition to Loading state if using Full strategy
+            if let LoadingStrategy::Full = loading_strategy {
                 let res =
                     mem::replace(&mut *query_data.state.borrow_mut(), QueryStateData::Pending)
                         .into_loading();

--- a/src/query.rs
+++ b/src/query.rs
@@ -181,14 +181,16 @@ impl<Q: QueryCapability> QueryStateData<Q> {
 /// Strategy for controlling whether queries transition to Loading state during invalidation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LoadingStrategy {
-    /// Always transition to Loading state when query is invalidated (default behavior).
+    /// Always transition to Loading state when query is invalidated.
     /// This causes components to re-render twice: once when entering Loading, once when Settled.
+    /// Use this when you want to show loading indicators during refetch.
     ///
     /// Example: `Settled("hello") -> Loading("hello") -> Settled("hello")`
     AlwaysShow,
 
-    /// Skip Loading state transition entirely. Query goes directly from Settled to Settled.
+    /// Skip Loading state transition entirely. Query goes directly from Settled to Settled (default).
     /// This prevents any loading indicators from showing during refetch, reducing re-renders from 2 to 1.
+    /// Best for background refetches where you don't want UI flashing.
     ///
     /// Example: `Settled("hello") -> Settled("world")`
     Skip,
@@ -196,8 +198,9 @@ pub enum LoadingStrategy {
     /// Skip both Loading transition AND state update if the result hasn't changed.
     /// Compares old and new results using PartialEq. If they're equal, no state update occurs
     /// and no re-renders are triggered at all (0 re-renders for identical results).
+    /// Best for polling/interval queries where data rarely changes.
     ///
-    /// **Note**: Requires `Q::Ok: PartialEq` and `Q::Err: PartialEq` (now enforced by trait bounds).
+    /// **Note**: Requires `Q::Ok: PartialEq` and `Q::Err: PartialEq` (enforced by trait bounds).
     ///
     /// Example with same result: `Settled("hello") -> (no change, 0 re-renders)`
     /// Example with different result: `Settled("hello") -> Settled("world") (1 re-render)`
@@ -206,7 +209,7 @@ pub enum LoadingStrategy {
 
 impl Default for LoadingStrategy {
     fn default() -> Self {
-        LoadingStrategy::AlwaysShow
+        LoadingStrategy::Skip
     }
 }
 
@@ -949,7 +952,7 @@ impl<Q: QueryCapability> GetQuery<Q> {
     /// Set the loading strategy for this query.
     ///
     /// Controls whether the query transitions to Loading state during invalidation.
-    /// Defaults to [LoadingStrategy::AlwaysShow].
+    /// Defaults to [LoadingStrategy::Skip].
     pub fn loading_strategy(self, loading_strategy: LoadingStrategy) -> Self {
         Self {
             loading_strategy,
@@ -1056,7 +1059,7 @@ impl<Q: QueryCapability> Query<Q> {
     /// Set the loading strategy for this query.
     ///
     /// Controls whether the query transitions to Loading state during invalidation.
-    /// Defaults to [LoadingStrategy::AlwaysShow].
+    /// Defaults to [LoadingStrategy::Skip].
     pub fn loading_strategy(self, loading_strategy: LoadingStrategy) -> Self {
         Self {
             loading_strategy,


### PR DESCRIPTION
## Summary

This PR introduces `LoadingStrategy` to control whether queries/mutations transition to Loading state during execution, and implements smart memoization to prevent unnecessary re-renders.

### Key Features

1. **Two LoadingStrategy variants:**
   - `Full`: Always shows Loading state (2 re-renders)
   - `Memoized` (default): Skips Loading, only updates if result changed (0-1 re-renders)

2. **Per-query configuration respected:**
   - Each query/mutation can set its own `loading_strategy`
   - Invalidation helpers respect per-query strategy by default
   - Override available via `.loading_strategy()` builder method

3. **Memoization with PartialEq:**
   - Compares old and new results using PartialEq
   - Skips re-renders when data unchanged
   - Added `PartialEq` trait bounds to `QueryCapability` and `MutationCapability`

### Breaking Changes

- **Trait bounds:** `QueryCapability` and `MutationCapability` now require `Ok: PartialEq` and `Err: PartialEq`
- **API:** LoadingStrategy enum changed (but backward compatible via builder pattern)

### Fixes Applied

1. **Settlement timestamp updates:** Fixed Memoized strategy to always update `settlement_instant`, preventing infinite refetch loops
2. **Strategy respected everywhere:** Interval task, stale checks, and `QueriesStorage::get` now use configured strategy
3. **Per-query configuration:** Invalidation helpers no longer override individual query strategies

### Usage Examples

```rust
// Default: Memoized strategy (no Loading state, memoized updates)
let query = use_query(Query::new(MyQuery));

// Explicit Full strategy (always shows Loading)
let query = use_query(
    Query::new(MyQuery)
        .loading_strategy(LoadingStrategy::Full)
);

// Invalidate with per-query strategies (default)
QueriesStorage::<MyQuery>::invalidate_all().await;

// Invalidate with override
QueriesStorage::<MyQuery>::invalidate_all()
    .loading_strategy(LoadingStrategy::Full)
    .await;
```

### Test Plan

- [x] All clippy checks pass
- [x] Code formatted with rustfmt
- [x] Compilation successful
- [ ] CI workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)